### PR TITLE
Fix erreurs applicatives : asset(null) dans les templates et roles en double array

### DIFF
--- a/src/Lucca/Bundle/CoreBundle/Resources/views/Home/HomePage.html.twig
+++ b/src/Lucca/Bundle/CoreBundle/Resources/views/Home/HomePage.html.twig
@@ -59,7 +59,7 @@
                     <a href="{{ path('lucca_content_dashboard', {'dep_code': department.code}) }}" class="text-decoration-none">
                         <div class="card card-custom shadow-sm">
                             <div class="card-image-container">
-                                <img src="{{ asset('setting.general.logo.name'|setting(department.code)) }}"
+                                <img src="{{ asset('setting.general.logo.name'|setting(department.code)|default('assets/logo/lucca-logo-texte-transparent.png')) }}"
                                      alt="{{ 'setting.general.ddtName.name'| setting(department.code) }}"
                                      class="img-fluid">
                             </div>

--- a/src/Lucca/Bundle/ThemeDocsUiKitBundle/Resources/views/Layout/layout.html.twig
+++ b/src/Lucca/Bundle/ThemeDocsUiKitBundle/Resources/views/Layout/layout.html.twig
@@ -147,7 +147,7 @@
             <div class="col-lg-3 col-xs-4 col-12">
                 <div class="animated fadeInLeft">
                     <a href={{ 'setting.general.urlGouv.name'|setting }}>
-                        <img src="{{ asset('assets/' ~ 'setting.general.departement.name'|setting ~ '/prefecture.jpg') }}"
+                        <img src="{{ asset('assets/' ~ ('setting.general.departement.name'|setting|default('default')) ~ '/prefecture.jpg') }}"
                              class="img-responsive logo-header" alt="{{ 'header.prefecture'|trans }}">
                     </a>
                 </div>
@@ -167,7 +167,7 @@
                 <div class="animated fadeInRight">
                     {% if 'setting.general.app.name'| setting != '-' %}
                         <a href="{{ path('lucca_content_dashboard') }}">
-                            <img src="{{ asset('setting.general.logo.name'|setting) }}"
+                            <img src="{{ asset('setting.general.logo.name'|setting|default('assets/logo/lucca-logo-texte-transparent.png')) }}"
                                  class="img-responsive logo-header" alt="{{ 'setting.general.app.name'| setting }}">
                         </a>
                     {% endif %}

--- a/src/Lucca/Bundle/UserBundle/DataFixtures/ORM/GroupFixtures.php
+++ b/src/Lucca/Bundle/UserBundle/DataFixtures/ORM/GroupFixtures.php
@@ -34,7 +34,7 @@ class GroupFixtures extends Fixture
             $newGroup = new Group();
             $newGroup->setName($group['name']);
             $newGroup->setDisplayed($group['displayed']);
-            $newGroup->setRoles([$group['role']]);
+            $newGroup->setRoles($group['role']);
 
             $manager->persist($newGroup);
         }

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -85,7 +85,7 @@
             <div class="col-lg-3 col-xs-4 col-12">
                 <div class="animated fadeInLeft">
                     <a href={{ 'setting.general.urlGouv.name'|setting }}>
-                        <img src="{{ asset('assets/' ~ 'setting.general.departement.name'|setting ~ '/prefecture.jpg') }}"
+                        <img src="{{ asset('assets/' ~ ('setting.general.departement.name'|setting|default('default')) ~ '/prefecture.jpg') }}"
                              class="img-responsive logo-header" alt="{{ 'header.prefecture'|trans }}">
                     </a>
                 </div>
@@ -105,7 +105,7 @@
                 <div class="animated fadeInRight">
                     {% if 'setting.general.app.name'| setting != '-' %}
                         <a href="{{ path('lucca_core_home') }}">
-                            <img src="{{ asset('setting.general.logo.name'|setting) }}"
+                            <img src="{{ asset('setting.general.logo.name'|setting|default('assets/logo/lucca-logo-texte-transparent.png')) }}"
                                  class="img-responsive logo-header" alt="{{ 'setting.general.app.name'| setting }}">
                         </a>
                     {% endif %}


### PR DESCRIPTION
## Resume
- **Fix `asset(null)` dans les templates Twig** : ajout d'un logo par defaut via `|default('assets/logo/lucca-logo-texte-transparent.png')` quand les settings ne sont pas encore configures, pour eviter le `TypeError` sur `asset()`
  - `HomePage.html.twig`
  - `ThemeDocsUiKitBundle/layout.html.twig`
  - `error403.html.twig`
- **Fix `GroupFixtures.setRoles()`** : les roles etaient encapsules dans un double array (`[['ROLE_SUPER_ADMIN']]` au lieu de `['ROLE_SUPER_ADMIN']`), ce qui causait "Array to string conversion" au login

## Fichiers modifies
- `src/Lucca/Bundle/CoreBundle/Resources/views/Home/HomePage.html.twig`
- `src/Lucca/Bundle/ThemeDocsUiKitBundle/Resources/views/Layout/layout.html.twig`
- `src/Lucca/Bundle/UserBundle/DataFixtures/ORM/GroupFixtures.php`
- `templates/bundles/TwigBundle/Exception/error403.html.twig`

## Plan de test
- [ ] Acceder a la homepage (`https://lucca.local/`) sans erreur 500
- [ ] Se connecter avec un utilisateur, verifier qu'il n'y a plus d'erreur "Array to string conversion"
- [ ] Verifier que le dashboard se charge correctement apres connexion

🤖 Generated with [Claude Code](https://claude.com/claude-code)